### PR TITLE
Additional UIView & UIStackView Extensions

### DIFF
--- a/Sources/Yalta.swift
+++ b/Sources/Yalta.swift
@@ -327,6 +327,21 @@ public extension UIView {
         [a, b, c, d].forEach { addSubview($0) }
         return Constraints(for: a, b, c, d, constraints)
     }
+    
+    @discardableResult @nonobjc public func insertSubview(_ a: UIView, at index: Int, constraints: (LayoutProxy<UIView>) -> Void) -> Constraints {
+        insertSubview(a, at: index)
+        return Constraints(for: a, constraints)
+    }
+    
+    @discardableResult @nonobjc public func insertSubview(_ a: UIView, aboveSubview siblingSubview: UIView, constraints: (LayoutProxy<UIView>) -> Void) -> Constraints {
+        insertSubview(a, aboveSubview: siblingSubview)
+        return Constraints(for: a, constraints)
+    }
+    
+    @discardableResult @nonobjc public func insertSubview(_ a: UIView, belowSubview siblingSubview: UIView, constraints: (LayoutProxy<UIView>) -> Void) -> Constraints {
+        insertSubview(a, belowSubview: siblingSubview)
+        return Constraints(for: a, constraints)
+    }
 }
 
 // MARK: - UIStackView + Constraints
@@ -350,6 +365,11 @@ public extension UIStackView {
     @discardableResult @nonobjc public func addArrangedSubview(_ a: UIView, _ b: UIView, _ c: UIView, _ d: UIView, constraints: (LayoutProxy<UIView>, LayoutProxy<UIView>, LayoutProxy<UIView>, LayoutProxy<UIView>) -> Void) -> Constraints {
         [a, b, c, d].forEach { addArrangedSubview($0) }
         return Constraints(for: a, b, c, d, constraints)
+    }
+    
+    @discardableResult @nonobjc public func insertArrangedSubview(_ a: UIView, at stackIndex: Int, constraints: (LayoutProxy<UIView>) -> Void) -> Constraints {
+        insertArrangedSubview(a, at: stackIndex)
+        return Constraints(for: a, constraints)
     }
 }
 

--- a/Sources/Yalta.swift
+++ b/Sources/Yalta.swift
@@ -329,6 +329,30 @@ public extension UIView {
     }
 }
 
+// MARK: - UIStackView + Constraints
+
+public extension UIStackView {
+    @discardableResult @nonobjc public func addArrangedSubview(_ a: UIView, constraints: (LayoutProxy<UIView>) -> Void) -> Constraints {
+        addArrangedSubview(a)
+        return Constraints(for: a, constraints)
+    }
+    
+    @discardableResult @nonobjc public func addArrangedSubview(_ a: UIView, _ b: UIView, constraints: (LayoutProxy<UIView>, LayoutProxy<UIView>) -> Void) -> Constraints {
+        [a, b].forEach { addArrangedSubview($0) }
+        return Constraints(for: a, b, constraints)
+    }
+    
+    @discardableResult @nonobjc public func addArrangedSubview(_ a: UIView, _ b: UIView, _ c: UIView, constraints: (LayoutProxy<UIView>, LayoutProxy<UIView>, LayoutProxy<UIView>) -> Void) -> Constraints {
+        [a, b, c].forEach { addArrangedSubview($0) }
+        return Constraints(for: a, b, c, constraints)
+    }
+    
+    @discardableResult @nonobjc public func addArrangedSubview(_ a: UIView, _ b: UIView, _ c: UIView, _ d: UIView, constraints: (LayoutProxy<UIView>, LayoutProxy<UIView>, LayoutProxy<UIView>, LayoutProxy<UIView>) -> Void) -> Constraints {
+        [a, b, c, d].forEach { addArrangedSubview($0) }
+        return Constraints(for: a, b, c, d, constraints)
+    }
+}
+
 // MARK: - Constraints (Arity)
 
 extension Constraints {

--- a/Tests/ConstraintsTests.swift
+++ b/Tests/ConstraintsTests.swift
@@ -180,3 +180,52 @@ class AddingSubviewsTests: XCTestCase {
         }
     }
 }
+
+class AddingArrangedSubviewsTests: XCTestCase {
+    let container = UIStackView()
+    let a = UIView()
+    let b = UIView()
+    let c = UIView()
+    let d = UIView()
+    
+    func testOne() {
+        container.addArrangedSubview(a) {
+            XCTAssertTrue($0.base.superview === container)
+            XCTAssertTrue($0.base === a)
+            return
+        }
+    }
+    
+    func testTwo() {
+        container.addArrangedSubview(a, b) {
+            XCTAssertTrue($0.base.superview === container)
+            XCTAssertTrue($1.base.superview === container)
+            XCTAssertTrue($0.base === a)
+            XCTAssertTrue($1.base === b)
+        }
+    }
+    
+    func testThree() {
+        container.addArrangedSubview(a, b, c) {
+            XCTAssertTrue($0.base.superview === container)
+            XCTAssertTrue($1.base.superview === container)
+            XCTAssertTrue($2.base.superview === container)
+            XCTAssertTrue($0.base === a)
+            XCTAssertTrue($1.base === b)
+            XCTAssertTrue($2.base === c)
+        }
+    }
+    
+    func testFour() {
+        container.addArrangedSubview(a, b, c, d) {
+            XCTAssertTrue($0.base.superview === container)
+            XCTAssertTrue($1.base.superview === container)
+            XCTAssertTrue($2.base.superview === container)
+            XCTAssertTrue($3.base.superview === container)
+            XCTAssertTrue($0.base === a)
+            XCTAssertTrue($1.base === b)
+            XCTAssertTrue($2.base === c)
+            XCTAssertTrue($3.base === d)
+        }
+    }
+}

--- a/Tests/ConstraintsTests.swift
+++ b/Tests/ConstraintsTests.swift
@@ -229,3 +229,47 @@ class AddingArrangedSubviewsTests: XCTestCase {
         }
     }
 }
+
+class InsertingSubviewTests: XCTestCase {
+    let container = UIView()
+    let a = UIView()
+    let b = UIView()
+    let c = UIView()
+    
+    func testOne() {
+        container.insertSubview(a, at: 0) {
+            XCTAssertTrue($0.base.superview === container)
+            XCTAssertTrue($0.base === a)
+            return
+        }
+    }
+    
+    func testTwo() {
+        container.insertSubview(b, aboveSubview: a) {
+            XCTAssertTrue($0.base.superview === container)
+            XCTAssertTrue($0.base === b)
+            return
+        }
+    }
+    
+    func testThree() {
+        container.insertSubview(c, belowSubview: a) {
+            XCTAssertTrue($0.base.superview === container)
+            XCTAssertTrue($0.base === c)
+            return
+        }
+    }
+}
+
+class InsertingArrangedSubviewTest: XCTestCase {
+    let container = UIStackView()
+    let a = UIView()
+    
+    func testOne() {
+        container.insertArrangedSubview(a, at: 0) {
+            XCTAssertTrue($0.base.superview === container)
+            XCTAssertTrue($0.base === a)
+            return
+        }
+    }
+}

--- a/Yalta.xcodeproj/project.pbxproj
+++ b/Yalta.xcodeproj/project.pbxproj
@@ -280,13 +280,13 @@
 					};
 					0CC3A0661D7476A700754E59 = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = NR8DLKJ7E6;
+						DevelopmentTeam = UY98EYPB8G;
 						LastSwiftMigration = 0910;
 						ProvisioningStyle = Automatic;
 					};
 					0CC3A0821D7477FB00754E59 = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = NR8DLKJ7E6;
+						DevelopmentTeam = UY98EYPB8G;
 						LastSwiftMigration = 0910;
 						ProvisioningStyle = Automatic;
 					};
@@ -420,8 +420,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -441,8 +443,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -465,7 +469,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
-				DEVELOPMENT_TEAM = NR8DLKJ7E6;
+				DEVELOPMENT_TEAM = UY98EYPB8G;
 				INFOPLIST_FILE = Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -483,7 +487,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
-				DEVELOPMENT_TEAM = NR8DLKJ7E6;
+				DEVELOPMENT_TEAM = UY98EYPB8G;
 				INFOPLIST_FILE = Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -499,7 +503,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
-				DEVELOPMENT_TEAM = NR8DLKJ7E6;
+				DEVELOPMENT_TEAM = UY98EYPB8G;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.kean.Yalta-tvOS-Tests";
@@ -518,7 +522,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
-				DEVELOPMENT_TEAM = NR8DLKJ7E6;
+				DEVELOPMENT_TEAM = UY98EYPB8G;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.kean.Yalta-tvOS-Tests";
@@ -645,8 +649,10 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -666,8 +672,10 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/Yalta.xcodeproj/project.pbxproj
+++ b/Yalta.xcodeproj/project.pbxproj
@@ -280,13 +280,13 @@
 					};
 					0CC3A0661D7476A700754E59 = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = UY98EYPB8G;
+						DevelopmentTeam = NR8DLKJ7E6;
 						LastSwiftMigration = 0910;
 						ProvisioningStyle = Automatic;
 					};
 					0CC3A0821D7477FB00754E59 = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = UY98EYPB8G;
+						DevelopmentTeam = NR8DLKJ7E6;
 						LastSwiftMigration = 0910;
 						ProvisioningStyle = Automatic;
 					};
@@ -420,10 +420,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -443,10 +441,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -469,7 +465,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
-				DEVELOPMENT_TEAM = UY98EYPB8G;
+				DEVELOPMENT_TEAM = NR8DLKJ7E6;
 				INFOPLIST_FILE = Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -487,7 +483,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
-				DEVELOPMENT_TEAM = UY98EYPB8G;
+				DEVELOPMENT_TEAM = NR8DLKJ7E6;
 				INFOPLIST_FILE = Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -503,7 +499,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
-				DEVELOPMENT_TEAM = UY98EYPB8G;
+				DEVELOPMENT_TEAM = NR8DLKJ7E6;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.kean.Yalta-tvOS-Tests";
@@ -522,7 +518,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
-				DEVELOPMENT_TEAM = UY98EYPB8G;
+				DEVELOPMENT_TEAM = NR8DLKJ7E6;
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.kean.Yalta-tvOS-Tests";
@@ -649,10 +645,8 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -672,10 +666,8 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";


### PR DESCRIPTION
Howdy!
This PR adds some additional extensions to the UIView and UIStackView classes, namely:

#### UIView
``` Swift
func insertSubview(_ a: UIView, at index: Int, constraints: (LayoutProxy<UIView>) -> Void) -> Constraints
func insertSubview(_ a: UIView, aboveSubview siblingSubview: UIView, constraints: (LayoutProxy<UIView>) -> Void) -> Constraints
func insertSubview(_ a: UIView, belowSubview siblingSubview: UIView, constraints: (LayoutProxy<UIView>) -> Void) -> Constraints
```

#### UIStackView
``` Swift
func addArrangedSubview(_ a: UIView, constraints: (LayoutProxy<UIView>) -> Void) -> Constraints
func addArrangedSubview(_ a: UIView, _ b: UIView, constraints: (LayoutProxy<UIView>, LayoutProxy<UIView>) -> Void) -> Constraints
func addArrangedSubview(_ a: UIView, _ b: UIView, _ c: UIView, constraints: (LayoutProxy<UIView>, LayoutProxy<UIView>, LayoutProxy<UIView>) -> Void) -> Constraints
func addArrangedSubview(_ a: UIView, _ b: UIView, _ c: UIView, _ d: UIView, constraints: (LayoutProxy<UIView>, LayoutProxy<UIView>, LayoutProxy<UIView>, LayoutProxy<UIView>) -> Void) -> Constraints
func insertArrangedSubview(_ a: UIView, at stackIndex: Int, constraints: (LayoutProxy<UIView>) -> Void) -> Constraints
```