### PR TITLE
Rename macOS .v10_16 to .v11

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     platforms: [
         .iOS(.v14),
         .tvOS(.v14),
-        .macOS(.v10_16),
+        .macOS(.v11),
     ],
     products: [
         .library(name: "Align", targets: ["Align"]),


### PR DESCRIPTION
Xcode 16 can't resolve a package's structure. Rename according to the suggestion

<img width="1359" alt="Screenshot 2024-10-12 at 14 23 11" src="https://github.com/user-attachments/assets/d0ebe8f2-29ab-40b3-b26c-967b11e2605e">

<img width="726" alt="Screenshot 2024-10-12 at 14 16 33" src="https://github.com/user-attachments/assets/983dcaa2-38d8-4be4-adcf-761d1e9d17c6">
